### PR TITLE
Migrate to JoyDB

### DIFF
--- a/dx_budgets/Cargo.lock
+++ b/dx_budgets/Cargo.lock
@@ -60,6 +60,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "dioxus",
+ "joydb",
  "once_cell",
  "serde",
  "sqlx",
@@ -2795,6 +2796,29 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "joydb"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a32fef7d1be0bdde33fc8a63844f384672fbc432a67d0b82964dc6692427b88"
+dependencies = [
+ "joydb_macros",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "joydb_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d1d00053c2832bf50ba1e320ee39fbbe77808147aaf909d2bde62bf842cde6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "js-sys"

--- a/dx_budgets/Cargo.lock
+++ b/dx_budgets/Cargo.lock
@@ -61,12 +61,9 @@ dependencies = [
  "chrono",
  "dioxus",
  "joydb",
- "once_cell",
  "serde",
- "sqlx",
  "tokio",
  "uuid",
- "welds",
 ]
 
 [[package]]
@@ -233,15 +230,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atoi"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,12 +332,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bitflags"
@@ -628,12 +610,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "const-serialize"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,21 +749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,15 +762,6 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -917,17 +869,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,9 +911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1561,12 +1500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenvy"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,15 +1525,6 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "encoding_rs"
@@ -1676,17 +1600,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "etcetera"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "euclid"
 version = "0.22.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,17 +1663,6 @@ checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "spin",
 ]
 
 [[package]]
@@ -1876,17 +1778,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
-]
-
-[[package]]
-name = "futures-intrusive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
-dependencies = [
- "futures-core",
- "lock_api",
- "parking_lot",
 ]
 
 [[package]]
@@ -2344,15 +2235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.4",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,24 +2257,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "home"
@@ -2865,9 +2729,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "libappindicator"
@@ -2910,12 +2771,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
 name = "libredox"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,17 +2778,6 @@ checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3083,16 +2927,6 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest",
-]
 
 [[package]]
 name = "memchr"
@@ -3282,50 +3116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3672,15 +3468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3838,27 +3625,6 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
-]
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
 ]
 
 [[package]]
@@ -4216,40 +3982,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.16",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4284,37 +4016,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
-dependencies = [
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -4633,16 +4340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4710,9 +4407,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "socket2"
@@ -4765,217 +4459,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
-name = "sqlx"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
-dependencies = [
- "sqlx-core",
- "sqlx-macros",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
-]
-
-[[package]]
-name = "sqlx-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
-dependencies = [
- "base64",
- "bytes",
- "chrono",
- "crc",
- "crossbeam-queue",
- "either",
- "event-listener",
- "futures-core",
- "futures-intrusive",
- "futures-io",
- "futures-util",
- "hashbrown 0.15.4",
- "hashlink",
- "indexmap 2.10.0",
- "log",
- "memchr",
- "once_cell",
- "percent-encoding",
- "rustls",
- "serde",
- "serde_json",
- "sha2",
- "smallvec",
- "thiserror 2.0.12",
- "tokio",
- "tokio-stream",
- "tracing",
- "url",
- "uuid",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "sqlx-macros"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
-dependencies = [
- "proc-macro2",
- "quote",
- "sqlx-core",
- "sqlx-macros-core",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "sqlx-macros-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
-dependencies = [
- "dotenvy",
- "either",
- "heck 0.5.0",
- "hex",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "sha2",
- "sqlx-core",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
- "syn 2.0.104",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "sqlx-mysql"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
-dependencies = [
- "atoi",
- "base64",
- "bitflags 2.9.1",
- "byteorder",
- "bytes",
- "chrono",
- "crc",
- "digest",
- "dotenvy",
- "either",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-util",
- "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa 1.0.15",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "percent-encoding",
- "rand 0.8.5",
- "rsa",
- "serde",
- "sha1",
- "sha2",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror 2.0.12",
- "tracing",
- "uuid",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-postgres"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
-dependencies = [
- "atoi",
- "base64",
- "bitflags 2.9.1",
- "byteorder",
- "chrono",
- "crc",
- "dotenvy",
- "etcetera",
- "futures-channel",
- "futures-core",
- "futures-util",
- "hex",
- "hkdf",
- "hmac",
- "home",
- "itoa 1.0.15",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "sha2",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror 2.0.12",
- "tracing",
- "uuid",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-sqlite"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
-dependencies = [
- "atoi",
- "chrono",
- "flume",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-intrusive",
- "futures-util",
- "libsqlite3-sys",
- "log",
- "percent-encoding",
- "serde",
- "serde_urlencoded",
- "sqlx-core",
- "thiserror 2.0.12",
- "tracing",
- "url",
- "uuid",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -5013,23 +4496,6 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
-
-[[package]]
-name = "stringprep"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
- "unicode-properties",
-]
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -5231,21 +4697,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5621,31 +5072,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5658,12 +5088,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -5786,12 +5210,6 @@ checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
-
-[[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -5958,24 +5376,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.2",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webview2-com"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6009,51 +5409,6 @@ dependencies = [
  "thiserror 1.0.69",
  "windows",
  "windows-core 0.58.0",
-]
-
-[[package]]
-name = "welds"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3154533301db82ad9af0e1efca060b117a4ef48d98009ec907c63a2b8ac5a38f"
-dependencies = [
- "anyhow",
- "async-trait",
- "thiserror 2.0.12",
- "welds-connections",
- "welds-macros",
-]
-
-[[package]]
-name = "welds-connections"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b70fe0e22d2d7a5fa697197efd3a7d534df634c0ee010f2c4a4544f273092d13"
-dependencies = [
- "async-trait",
- "log",
- "sqlx",
-]
-
-[[package]]
-name = "welds-macros"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c3009fb59357d118003d5ccd7955250a7faff2b664d43fea6625ea35bfd091"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "whoami"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
-dependencies = [
- "redox_syscall",
- "wasite",
 ]
 
 [[package]]

--- a/dx_budgets/Cargo.lock
+++ b/dx_budgets/Cargo.lock
@@ -2387,7 +2387,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2772,9 +2772,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -2844,9 +2844,9 @@ dependencies = [
 
 [[package]]
 name = "lucide-dioxus"
-version = "2.15.0"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d06f27420e7a960d76a02f43819fba2fb3a513738714cc6262c02d9fd256e5c"
+checksum = "3c4c63113fb2654f34be28a7f333c59e5be026f7b608f6968b18886187d513cf"
 dependencies = [
  "dioxus",
 ]
@@ -3871,18 +3871,18 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.15"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -3983,9 +3983,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -4410,16 +4410,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -4700,9 +4690,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4713,10 +4703,10 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.5.10",
+ "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5607,7 +5597,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -5658,10 +5648,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/dx_budgets/Cargo.toml
+++ b/dx_budgets/Cargo.toml
@@ -15,6 +15,7 @@ uuid = { version = "1.1.2", features = ["v4", "js", "serde"] }
 chrono = { version="0.4.41", features = ["serde"] }
 serde = { version = "1.0.188", features = ["derive"] }
 anyhow = "1.0.98"
+joydb = { version = "0.1.0", features = ["json"] }
 
 # workspace
 ui = { path = "ui" }

--- a/dx_budgets/api/Cargo.toml
+++ b/dx_budgets/api/Cargo.toml
@@ -5,9 +5,6 @@ edition = "2021"
 
 [dependencies]
 dioxus = { workspace = true, features = ["fullstack"] }
-welds = { version = "0.4.16", features = ["sqlite", "migrations"], optional = true }
-sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "tls-rustls", "sqlite", "chrono", "uuid"], optional = true }
-once_cell = { version = "1.21.3", optional = true }
 tokio = { version = "1.46.0", features = ["full"], optional = true }
 uuid = { workspace = true, features = ["v4", "js", "serde"] }
 chrono = { workspace = true, features = ["serde"] }
@@ -19,4 +16,4 @@ joydb = { version = "0.1.0", features = ["json"], workspace = true }
 web = []
 desktop = []
 mobile = []
-server = ["once_cell", "welds", "sqlx", "tokio"]
+server = ["tokio"]

--- a/dx_budgets/api/Cargo.toml
+++ b/dx_budgets/api/Cargo.toml
@@ -13,6 +13,7 @@ uuid = { workspace = true, features = ["v4", "js", "serde"] }
 chrono = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 anyhow = { workspace = true }
+joydb = { version = "0.1.0", features = ["json"], workspace = true }
 
 [features]
 web = []

--- a/dx_budgets/api/src/lib.rs
+++ b/dx_budgets/api/src/lib.rs
@@ -21,7 +21,9 @@ joydb::state! {
     }
 
 // Define the database (combination of state and adapter)
+#[cfg(feature = "server")]
 type Db = Joydb<AppState, JsonAdapter>;
+#[cfg(feature = "server")]
 pub mod db {
     use crate::models::budget::Budget;
     use crate::models::budget_item::BudgetItem;
@@ -32,15 +34,12 @@ pub mod db {
     use dioxus::prelude::{Signal, UnsyncStorage};
     use uuid::Uuid;
     use Default;
-    use std::time::Duration;
     use chrono::NaiveDate;
     use dioxus::fullstack::once_cell::sync::Lazy;
     use joydb::JoydbError;
-    const DATA_PATH: &str = "data.json";
     pub static CLIENT: Lazy<Db> = Lazy::new(|| {
         tracing::info!("Init DB Client");
-        let client = Db::open("./data.json").unwrap();
-
+        let client = Db::open("~/data.json").unwrap();
         // Run migrations
         tracing::info!("Insert Default Data");
         match get_default_user(Some(&client)) {

--- a/dx_budgets/api/src/lib.rs
+++ b/dx_budgets/api/src/lib.rs
@@ -8,17 +8,27 @@ use crate::models::user::User;
 use chrono::NaiveDate;
 use dioxus::logger::tracing;
 use dioxus::prelude::*;
+use joydb::adapters::JsonAdapter;
+use joydb::Joydb;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use crate::models::budget_item::BudgetItem;
 
 const DEFAULT_USER_EMAIL: &str = "tommie.nygren@gmail.com";
+// Define the state
+joydb::state! {
+        AppState,
+        models: [User, Budget, BudgetItem, BudgetTransaction],
+    }
 
+// Define the database (combination of state and adapter)
+type Db = Joydb<AppState, JsonAdapter>;
 pub mod db {
     use crate::models::budget::Budget;
     use crate::models::budget_item::BudgetItem;
     use crate::models::budget_transaction::BudgetTransaction;
     use crate::models::user::User;
-    use crate::{migrations, BudgetItemView, BudgetOverview, DEFAULT_USER_EMAIL};
+    use crate::{migrations, BudgetItemView, BudgetOverview, Db, DEFAULT_USER_EMAIL};
     use dioxus::logger::tracing;
     use dioxus::prelude::{Signal, UnsyncStorage};
     use once_cell::sync::Lazy;
@@ -28,14 +38,7 @@ pub mod db {
     use joydb::adapters::JsonAdapter;
     use joydb::{Joydb, JoydbError};
 
-    // Define the state
-    joydb::state! {
-        AppState,
-        models: [User, Budget, BudgetItem, BudgetTransaction],
-    }
-
-    // Define the database (combination of state and adapter)
-    type Db = Joydb<AppState, JsonAdapter>;
+    
 
     pub static CLIENT: Lazy<Db> = Lazy::new(|| {
         tracing::info!("Init DB Client");

--- a/dx_budgets/api/src/lib.rs
+++ b/dx_budgets/api/src/lib.rs
@@ -32,11 +32,11 @@ pub mod db {
     use dioxus::prelude::{Signal, UnsyncStorage};
     use uuid::Uuid;
     use Default;
+    use std::time::Duration;
     use chrono::NaiveDate;
     use dioxus::fullstack::once_cell::sync::Lazy;
-    use joydb::adapters::JsonAdapter;
-    use joydb::{Joydb, JoydbError};
-
+    use joydb::JoydbError;
+    const DATA_PATH: &str = "data.json";
     pub static CLIENT: Lazy<Db> = Lazy::new(|| {
         tracing::info!("Init DB Client");
         let client = Db::open("./data.json").unwrap();
@@ -72,7 +72,7 @@ pub mod db {
         }
     }
 
-    pub async fn get_budget_overview(
+    pub fn get_budget_overview(
         id: Uuid,
         client: Option<&Db>,
     ) -> anyhow::Result<BudgetOverview> {
@@ -152,7 +152,7 @@ pub mod db {
         }
     }
 
-    pub async fn user_exists(email: &str, client: Option<&Db>) -> anyhow::Result<bool> {
+    pub fn user_exists(email: &str, client: Option<&Db>) -> anyhow::Result<bool> {
         match client_from_option(client).get_all_by(|u: &User| u.email == email) {
             Ok(users) => {Ok(!users.is_empty())},
             Err(e) => {
@@ -226,7 +226,7 @@ pub mod db {
         
     }
 
-    pub async fn add_budget_item(
+    pub fn add_budget_item(
         budget_id: Uuid,
         name: String,
         item_type: String,
@@ -402,7 +402,7 @@ pub struct BudgetOverview {
 
 #[server]
 pub async fn get_budget_overview(id: Uuid) -> Result<BudgetOverview, ServerFnError> {
-    match db::get_budget_overview(id, None).await {
+    match db::get_budget_overview(id, None) {
         Ok(overview) => Ok(overview),
         Err(e) => {
             tracing::error!(error = %e, "Could not get budget overview");

--- a/dx_budgets/api/src/migrations/m20250701150318_create_table_users.rs
+++ b/dx_budgets/api/src/migrations/m20250701150318_create_table_users.rs
@@ -1,9 +1,9 @@
-#[cfg(feature = "server")]
+
 use welds::errors::Result;
-#[cfg(feature = "server")]
+
 use welds::migrations::prelude::*;
 
-#[cfg(feature = "server")]
+
 pub(super) fn step(_state: &TableState) -> Result<MigrationStep> {
     let m = create_table("users")
         .id(|c| c("id", Type::Uuid))

--- a/dx_budgets/api/src/migrations/m20250710145549_create_table_budgets.rs
+++ b/dx_budgets/api/src/migrations/m20250710145549_create_table_budgets.rs
@@ -1,9 +1,9 @@
-#[cfg(feature = "server")]
+
 use welds::errors::Result;
-#[cfg(feature = "server")]
+
 use welds::migrations::prelude::*;
 
-#[cfg(feature = "server")]
+
 pub(super) fn step(_state: &TableState) -> Result<MigrationStep> {
     let m = create_table("budgets")
         .id(|c| c("id", Type::Uuid))

--- a/dx_budgets/api/src/migrations/m20250710145616_create_table_budget_items.rs
+++ b/dx_budgets/api/src/migrations/m20250710145616_create_table_budget_items.rs
@@ -1,7 +1,7 @@
 use welds::errors::Result;
-#[cfg(feature = "server")]
+
 use welds::migrations::prelude::*;
-#[cfg(feature = "server")]
+
 pub(super) fn step(_state: &TableState) -> Result<MigrationStep> {
     let m = create_table("budget_items")
         .id(|c| c("id", Type::Uuid))

--- a/dx_budgets/api/src/migrations/m20250721110153_create_table_budget_transactions.rs
+++ b/dx_budgets/api/src/migrations/m20250721110153_create_table_budget_transactions.rs
@@ -1,8 +1,8 @@
 use welds::errors::Result;
-#[cfg(feature = "server")]
+
 use welds::migrations::prelude::*;
 
-#[cfg(feature = "server")]
+
 pub(super) fn step(_state: &TableState) -> Result<MigrationStep> {
     let m = create_table("budget_transactions")
         .id(|c| c("id", Type::Uuid))

--- a/dx_budgets/api/src/migrations/m20250726123221_create_table_add_item_type_to_budget_items.rs
+++ b/dx_budgets/api/src/migrations/m20250726123221_create_table_add_item_type_to_budget_items.rs
@@ -1,8 +1,8 @@
 use welds::errors::Result;
-#[cfg(feature = "server")]
+
 use welds::migrations::prelude::*;
 
-#[cfg(feature = "server")]
+
 pub(super) fn step(state: &TableState) -> Result<MigrationStep> {
     let alter = change_table(state, "budget_items")?;
     let m = alter.add_column("item_type", Type::String);

--- a/dx_budgets/api/src/migrations/mod.rs
+++ b/dx_budgets/api/src/migrations/mod.rs
@@ -1,19 +1,19 @@
-#[cfg(feature = "server")]
+
 use welds::errors::Result;
-#[cfg(feature = "server")]
+
 use welds::migrations::prelude::*;
-#[cfg(feature = "server")]
+
 mod m20250701150318_create_table_users;
-#[cfg(feature = "server")]
+
 mod m20250710145549_create_table_budgets;
-#[cfg(feature = "server")]
+
 mod m20250710145616_create_table_budget_items;
-#[cfg(feature = "server")]
+
 mod m20250721110153_create_table_budget_transactions;
-#[cfg(feature = "server")]
+
 mod m20250726123221_create_table_add_item_type_to_budget_items;
 
-#[cfg(feature = "server")]
+
 pub async fn up(client: &dyn welds::TransactStart) -> Result<()> {
     let list: Vec<MigrationFn> = vec![
         m20250701150318_create_table_users::step,

--- a/dx_budgets/api/src/models/budget.rs
+++ b/dx_budgets/api/src/models/budget.rs
@@ -14,6 +14,23 @@ pub struct Budget {
     pub user_id: Uuid,
 }
 
+impl Budget {
+    pub fn new(name: &str, default_budget: bool, user_id: Uuid) -> Budget {
+        Budget {
+            id: Uuid::new_v4(),
+            name: name.to_string(),
+            default_budget,
+            created_at: chrono::Utc::now().naive_utc(),
+            updated_at: chrono::Utc::now().naive_utc(),
+            user_id,
+        }
+    }
+    
+    pub fn touch(&mut self) {
+        self.updated_at = chrono::Utc::now().naive_utc();
+    }
+}
+
 pub fn before_create(budget: &mut Budget) -> welds::errors::Result<()> {
     budget.id = Uuid::new_v4();
     budget.created_at = chrono::Utc::now().naive_utc();

--- a/dx_budgets/api/src/models/budget.rs
+++ b/dx_budgets/api/src/models/budget.rs
@@ -1,8 +1,6 @@
-use crate::User;
-use crate::models::budget_item::BudgetItem;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use joydb::{Joydb, adapters::JsonAdapter, Model};
+use joydb::Model;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Model)]
 pub struct Budget {
@@ -29,16 +27,4 @@ impl Budget {
     pub fn touch(&mut self) {
         self.updated_at = chrono::Utc::now().naive_utc();
     }
-}
-
-pub fn before_create(budget: &mut Budget) -> welds::errors::Result<()> {
-    budget.id = Uuid::new_v4();
-    budget.created_at = chrono::Utc::now().naive_utc();
-    budget.updated_at = chrono::Utc::now().naive_utc();
-    Ok(())
-}
-
-pub fn before_update(budget: &mut Budget) -> welds::errors::Result<()> {
-    budget.updated_at = chrono::Utc::now().naive_utc();
-    Ok(())
 }

--- a/dx_budgets/api/src/models/budget.rs
+++ b/dx_budgets/api/src/models/budget.rs
@@ -1,23 +1,11 @@
 use crate::User;
-#[cfg(feature = "server")]
 use crate::models::budget_item::BudgetItem;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-#[cfg(feature = "server")]
-use welds::WeldsModel;
+use joydb::{Joydb, adapters::JsonAdapter, Model};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[cfg_attr(feature = "server", derive(WeldsModel))]
-#[cfg_attr(feature = "server", welds(table = "budgets"))]
-#[cfg_attr(feature = "server", welds(BelongsTo(user, User, "user_id")))]
-#[cfg_attr(
-    feature = "server",
-    welds(HasMany(budget_items, BudgetItem, "budget_id"))
-)]
-#[cfg_attr(feature = "server", welds(BeforeCreate(before_create)))]
-#[cfg_attr(feature = "server", welds(BeforeUpdate(before_update)))]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Model)]
 pub struct Budget {
-    #[cfg_attr(feature = "server", welds(primary_key))]
     pub id: Uuid,
     pub name: String,
     pub default_budget: bool,
@@ -26,7 +14,6 @@ pub struct Budget {
     pub user_id: Uuid,
 }
 
-#[cfg(feature = "server")]
 pub fn before_create(budget: &mut Budget) -> welds::errors::Result<()> {
     budget.id = Uuid::new_v4();
     budget.created_at = chrono::Utc::now().naive_utc();
@@ -34,7 +21,6 @@ pub fn before_create(budget: &mut Budget) -> welds::errors::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "server")]
 pub fn before_update(budget: &mut Budget) -> welds::errors::Result<()> {
     budget.updated_at = chrono::Utc::now().naive_utc();
     Ok(())

--- a/dx_budgets/api/src/models/budget_item.rs
+++ b/dx_budgets/api/src/models/budget_item.rs
@@ -1,28 +1,9 @@
-#[cfg(feature = "server")]
-use crate::models::budget::Budget;
-#[cfg(feature = "server")]
-use crate::models::budget_transaction::BudgetTransaction;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-#[cfg(feature = "server")]
-use welds::WeldsModel;
+use joydb::{Model};
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[cfg_attr(feature = "server", derive(WeldsModel))]
-#[cfg_attr(feature = "server", welds(table = "budget_items"))]
-#[cfg_attr(feature = "server", welds(BelongsTo(budget, Budget, "budget_id")))]
-#[cfg_attr(
-    feature = "server",
-    welds(HasMany(outgoing_budget_transactions, BudgetTransaction, "from_budget_item"))
-)]
-#[cfg_attr(
-    feature = "server",
-    welds(HasMany(incoming_budget_transactions, BudgetTransaction, "to_budget_item"))
-)]
-#[cfg_attr(feature = "server", welds(BeforeCreate(before_create)))]
-#[cfg_attr(feature = "server", welds(BeforeUpdate(before_update)))]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Model)]
 pub struct BudgetItem {
-    #[cfg_attr(feature = "server", welds(primary_key))]
     pub id: Uuid,
     pub name: String,
     pub item_type: String,
@@ -46,7 +27,7 @@ impl BudgetItem {
     }
 }
 
-#[cfg(feature = "server")]
+
 pub fn before_create(budget_item: &mut BudgetItem) -> welds::errors::Result<()> {
     budget_item.id = Uuid::new_v4();
     budget_item.created_at = chrono::Utc::now().naive_utc();
@@ -54,7 +35,7 @@ pub fn before_create(budget_item: &mut BudgetItem) -> welds::errors::Result<()> 
     Ok(())
 }
 
-#[cfg(feature = "server")]
+
 pub fn before_update(budget_item: &mut BudgetItem) -> welds::errors::Result<()> {
     budget_item.updated_at = chrono::Utc::now().naive_utc();
     Ok(())

--- a/dx_budgets/api/src/models/budget_item.rs
+++ b/dx_budgets/api/src/models/budget_item.rs
@@ -17,12 +17,14 @@ pub struct BudgetItem {
 impl BudgetItem {
     pub fn new_from_user(budget_id: Uuid, name: &str, item_type: &str, expected_at: chrono::NaiveDate, created_by: Uuid) -> BudgetItem {
         BudgetItem {
+            id: Uuid::new_v4(),
             budget_id,
             name: name.to_string(),
             item_type: item_type.to_string(),
             expected_at,
+            created_at: chrono::Utc::now().naive_utc(),
+            updated_at: chrono::Utc::now().naive_utc(),
             created_by,
-            ..Default::default()
         }
     }
 }

--- a/dx_budgets/api/src/models/budget_item.rs
+++ b/dx_budgets/api/src/models/budget_item.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use joydb::{Model};
+use joydb::Model;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Model)]
 pub struct BudgetItem {
@@ -27,18 +27,4 @@ impl BudgetItem {
             created_by,
         }
     }
-}
-
-
-pub fn before_create(budget_item: &mut BudgetItem) -> welds::errors::Result<()> {
-    budget_item.id = Uuid::new_v4();
-    budget_item.created_at = chrono::Utc::now().naive_utc();
-    budget_item.updated_at = chrono::Utc::now().naive_utc();
-    Ok(())
-}
-
-
-pub fn before_update(budget_item: &mut BudgetItem) -> welds::errors::Result<()> {
-    budget_item.updated_at = chrono::Utc::now().naive_utc();
-    Ok(())
 }

--- a/dx_budgets/api/src/models/budget_transaction.rs
+++ b/dx_budgets/api/src/models/budget_transaction.rs
@@ -17,12 +17,14 @@ pub struct BudgetTransaction {
 impl BudgetTransaction {
     pub fn new_from_user(text: &str, amount: f32, from_budget_item: Option<Uuid>, to_budget_item: Uuid, created_by: Uuid) -> BudgetTransaction {
         BudgetTransaction {
+            id: Uuid::new_v4(),
             text: text.to_string(),
             amount,
             to_budget_item,
             from_budget_item,
+            created_at: chrono::Utc::now().naive_utc(),
+            updated_at: chrono::Utc::now().naive_utc(),
             created_by,
-            ..Default::default()
         }
     }
 }

--- a/dx_budgets/api/src/models/budget_transaction.rs
+++ b/dx_budgets/api/src/models/budget_transaction.rs
@@ -1,20 +1,9 @@
-#[cfg(feature = "server")]
-use crate::models::budget_item::BudgetItem;
+use joydb::Model;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-#[cfg(feature = "server")]
-use welds::WeldsModel;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[cfg_attr(feature = "server", derive(WeldsModel))]
-#[cfg_attr(feature = "server", welds(table = "budget_transactions"))]
-#[cfg_attr(feature = "server", welds(BelongsTo(to_budget_item, BudgetItem, "to_budget_item")))]
-#[cfg_attr(feature = "server", welds(BelongsTo(from_budget_item, BudgetItem, "from_budget_item")))]
-#[cfg_attr(feature = "server", welds(BelongsTo(created_by, BudgetItem, "created_by")))]
-#[cfg_attr(feature = "server", welds(BeforeCreate(before_create)))]
-#[cfg_attr(feature = "server", welds(BeforeUpdate(before_update)))]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Model)]
 pub struct BudgetTransaction {
-    #[cfg_attr(feature = "server", welds(primary_key))]
     pub id: Uuid,
     pub text: String,
     pub amount: f32,
@@ -40,7 +29,7 @@ impl BudgetTransaction {
 
 
 
-#[cfg(feature = "server")]
+
 pub fn before_create(budget_transaction: &mut BudgetTransaction) -> welds::errors::Result<()>{
     budget_transaction.id = Uuid::new_v4();
     budget_transaction.created_at = chrono::Utc::now().naive_utc();
@@ -48,7 +37,7 @@ pub fn before_create(budget_transaction: &mut BudgetTransaction) -> welds::error
     Ok(())
 }
 
-#[cfg(feature = "server")]
+
 pub fn before_update(budget_transaction: &mut BudgetTransaction) -> welds::errors::Result<()>{
     budget_transaction.updated_at = chrono::Utc::now().naive_utc();
     Ok(())

--- a/dx_budgets/api/src/models/budget_transaction.rs
+++ b/dx_budgets/api/src/models/budget_transaction.rs
@@ -28,20 +28,3 @@ impl BudgetTransaction {
         }
     }
 }
-
-
-
-
-pub fn before_create(budget_transaction: &mut BudgetTransaction) -> welds::errors::Result<()>{
-    budget_transaction.id = Uuid::new_v4();
-    budget_transaction.created_at = chrono::Utc::now().naive_utc();
-    budget_transaction.updated_at = chrono::Utc::now().naive_utc();
-    Ok(())
-}
-
-
-pub fn before_update(budget_transaction: &mut BudgetTransaction) -> welds::errors::Result<()>{
-    budget_transaction.updated_at = chrono::Utc::now().naive_utc();
-    Ok(())
-}
-

--- a/dx_budgets/api/src/models/user.rs
+++ b/dx_budgets/api/src/models/user.rs
@@ -13,3 +13,17 @@ pub struct User {
     pub phone: Option<String>,
     pub birthday: Option<NaiveDate>,
 }
+
+impl User {
+    pub fn new(user_name: &str, email: &str, first_name: &str, last_name: &str, phone: Option<String>, birthday: Option<NaiveDate>) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            user_name: user_name.to_string(),
+            email: email.to_string(),
+            first_name: first_name.to_string(),
+            last_name: last_name.to_string(),
+            phone,
+            birthday,
+        }
+    }
+}

--- a/dx_budgets/api/src/models/user.rs
+++ b/dx_budgets/api/src/models/user.rs
@@ -1,14 +1,10 @@
 use chrono::NaiveDate;
+use joydb::Model;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-#[cfg(feature = "server")]
-use welds::WeldsModel;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "server", derive(WeldsModel))]
-#[cfg_attr(feature = "server", welds(table = "users"))]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Model)]
 pub struct User {
-    #[cfg_attr(feature = "server", welds(primary_key))]
     pub id: Uuid,
     pub user_name: String,
     pub email: String,

--- a/dx_budgets/api/src/models/user.rs
+++ b/dx_budgets/api/src/models/user.rs
@@ -1,5 +1,5 @@
 use chrono::NaiveDate;
-use joydb::{JoydbError, Model};
+use joydb::Model;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use crate::Db;

--- a/dx_budgets/api/src/models/user.rs
+++ b/dx_budgets/api/src/models/user.rs
@@ -2,8 +2,6 @@ use chrono::NaiveDate;
 use joydb::Model;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use crate::Db;
-use crate::models::budget::Budget;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Model)]
 pub struct User {
@@ -26,13 +24,6 @@ impl User {
             last_name: last_name.to_string(),
             phone,
             birthday,
-        }
-    }
-    
-    pub fn get_default_budget(&self, db: &Db) -> anyhow::Result<Budget> {
-        match db.get_all_by(|b: &Budget| b.user_id == self.id && b.default_budget) {
-            Ok(mut budgets) => { Ok(budgets.remove(0)) },
-            Err(e) => { Err(anyhow::Error::from(e)) }
         }
     }
 }

--- a/dx_budgets/api/src/models/user.rs
+++ b/dx_budgets/api/src/models/user.rs
@@ -1,7 +1,9 @@
 use chrono::NaiveDate;
-use joydb::Model;
+use joydb::{JoydbError, Model};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use crate::Db;
+use crate::models::budget::Budget;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, Model)]
 pub struct User {
@@ -24,6 +26,13 @@ impl User {
             last_name: last_name.to_string(),
             phone,
             birthday,
+        }
+    }
+    
+    pub fn get_default_budget(&self, db: &Db) -> anyhow::Result<Budget> {
+        match db.get_all_by(|b: &Budget| b.user_id == self.id && b.default_budget) {
+            Ok(mut budgets) => { Ok(budgets.remove(0)) },
+            Err(e) => { Err(anyhow::Error::from(e)) }
         }
     }
 }

--- a/dx_budgets/desktop/src/main.rs
+++ b/dx_budgets/desktop/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
     dioxus::logger::init(Level::INFO).expect("failed to init logger");
 
     
-    let _ = api::db::CLIENT.as_ref();
+    let _ = api::db::CLIENT;
     
     
     launch(App);

--- a/dx_budgets/desktop/src/main.rs
+++ b/dx_budgets/desktop/src/main.rs
@@ -39,7 +39,7 @@ const MAIN_CSS: Asset = asset!("/assets/main.css");
 fn main() {
     dioxus::logger::init(Level::INFO).expect("failed to init logger");
 
-    #[cfg(feature = "server")]
+    
     let _ = api::db::CLIENT.as_ref();
     
     

--- a/dx_budgets/desktop/src/main.rs
+++ b/dx_budgets/desktop/src/main.rs
@@ -38,10 +38,9 @@ const MAIN_CSS: Asset = asset!("/assets/main.css");
 
 fn main() {
     dioxus::logger::init(Level::INFO).expect("failed to init logger");
-
     
+    #[cfg(feature = "server")]
     let _ = api::db::CLIENT;
-    
     
     launch(App);
 }

--- a/dx_budgets/web/src/main.rs
+++ b/dx_budgets/web/src/main.rs
@@ -18,7 +18,7 @@ const FAVICON: Asset = asset!("/assets/favicon.ico");
 const MAIN_CSS: Asset = asset!("/assets/main.css");
 
 fn main() {
-    #[cfg(feature = "server")]
+    
     let _ = api::db::CLIENT.as_ref();
     launch(App);
 }


### PR DESCRIPTION
Migrates the database access to use JoyDB instead of Weld. This reduces complexity dealing with migrations etc,
enabling us to faster iterate over models.